### PR TITLE
Add support for converting helper/partial params to inline requires

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,9 +38,10 @@ A file "/folder/file.handlebars".
 {{../helper}} {{$module/helper}} are resolved similarly to partials.
 ```
 
-Two query options are supported:
+The following query options are supported:
  - *helperDirs*: Defines additional directories to be searched for helpers. Allows helpers to be defined in a directory and used globally without relative paths.
  - *extensions*: Searches for templates with alternate extensions. Defaults are .handlebars, .hbs, and '' (no extension).
+ - *inlineRequires*: Defines a regex that identifies strings within helper/partial parameters that should be replaced by inline require statements.
 
 See [`webpack`](https://github.com/webpack/webpack) documentation for more information regarding loaders.
 

--- a/lib/fastreplace.js
+++ b/lib/fastreplace.js
@@ -1,0 +1,40 @@
+var placeholderRegex = /xxxxREPLACExxxx[0-9\.]+xxxx/g;
+
+function getPlaceholder() {
+  return 'xxxxREPLACExxxx' + Math.random() + 'xxxx';
+}
+
+function replaceWithPlaceholders(str, replacements) {
+  var content = [str];
+  var placeholderMap = {};
+
+  for (var i = replacements.length - 1, repl; repl = replacements[i--];) {
+    do {
+      var placeholder = getPlaceholder();
+    } while(placeholderMap[placeholder]);
+    placeholderMap[placeholder] = repl.value;
+
+    var x = content.pop();
+    content.push(x.substr(repl.start + repl.length));
+    content.push(placeholder);
+    content.push(x.substr(0, repl.start));
+  }
+  content.reverse();
+
+  return {
+    content: content.join(""),
+    placeholderMap: placeholderMap
+  };
+}
+
+module.exports = function (str, replacements, replaceFn) {
+  var withPlaceholders = replaceWithPlaceholders(str, replacements);
+  var placeholderMap = withPlaceholders.placeholderMap;
+
+  placeholderRegex.lastIndex = 0;
+  return withPlaceholders.content.replace(placeholderRegex, function(match) {
+    var origValue = placeholderMap[match];
+    if (!origValue) return match;
+    return replaceFn(origValue);
+  });
+};

--- a/lib/findNestedRequires.js
+++ b/lib/findNestedRequires.js
@@ -1,0 +1,33 @@
+var fastparse = require("fastparse");
+
+var findNestedRequires = function(match, strUntilValue, name, value, index) {
+  if(!this.requiresPattern.test(value)) return;
+  this.results.push({
+    start: index + strUntilValue.length,
+    length: value.length,
+    value: value
+  });
+};
+
+var parser = new fastparse({
+  outside: {
+    "<!--.*?-->": true, // html comments
+    "<![CDATA[.*?]]>": true, // cdata
+    "<[!\\?].*?>": true, // scripting tags
+    "<\/[^>]+>": true, // closing tag
+    "<([a-zA-Z\\-:]+)\\s*": "inside" // opening tag
+  },
+  inside: {
+    "((\\n|r|t)|\\s)+": true, // eat up whitespace (including escaped)
+    ">": "outside", // end of attributes
+    "(([a-zA-Z\\-]+)\\s*=\\s*\\\\\")([^\"]*)\\\\\"": findNestedRequires, // quoted attributes
+    "(([a-zA-Z\\-]+)\\s*=\\s*)([^\\s>]+)": findNestedRequires // non-quoted attributes
+  }
+});
+
+module.exports = function(str, requiresPattern) {
+  return parser.parse("outside", str, {
+    requiresPattern: requiresPattern,
+    results: []
+  }).results;
+};

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "description": "handlebars loader module for webpack",
   "dependencies": {
     "async": "~0.2.10",
+    "fastparse": "^1.0.0",
     "loader-utils": "0.2.x"
   },
   "peerDependencies": {

--- a/test/test.js
+++ b/test/test.js
@@ -115,4 +115,19 @@ describe('handlebars-loader', function () {
     });
   });
 
+  it('allows specifying inline requires', function (done) {
+    testTemplate(loader, './with-inline-requires.handlebars', {
+      query: '?inlineRequires=^images\/',
+      stubs: {
+        './image': function (text) { return 'Image URL: ' + text; },
+        'images/path/to/image': 'http://www.gravatar.com/avatar/205e460b479e2e5b48aec07710c08d50'
+      }
+    }, function (output, require) {
+      assert.ok(output, 'generated output');
+      assert.ok(require.calledWith('images/path/to/image'),
+        'should have required image path');
+      done();
+    });
+  });
+
 });

--- a/test/with-inline-requires.handlebars
+++ b/test/with-inline-requires.handlebars
@@ -1,0 +1,1 @@
+{{image "images/path/to/image"}}


### PR DESCRIPTION
In some cases it is desired to pass a module to a Handlebars partial or helper.
Normally, this can be accomplished with template data:

``` javascript
var data = {
  module: require('path/to/module')
};

template.render(data);
```

``` html
{{helperThatWantsModule module}}
```

However, it is often simpler to just say what you need inside the template file itself:

``` html
{{helperThatWantsModule "path/to/module"}}
```

In my specific use-case, which inspired this PR, I have a special helper that is responsible
for setting up and rendering subviews to a parent view:

``` html
{{$view "path/to/subview" subviewArg="..."}}
```

Having the handlebars webpack loader identify these modules as dependencies and require them
inline is preferable, and not very difficult. By adding a `nestedRequires` option, which allows
the user to specify a conditional regex that defines what strings should be treated as modules.
As strings are processed by the Handlebars compiler, it can then replace them on the fly.
