### PR TITLE
Adding tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,12 +1,8 @@
 {
   "name": "handlebars-loader",
   "contributors": [
-    {
-      "name": "Alan @altano"
-    },
-    {
-      "name": "Tobias Koppers @sokra"
-    }
+    "Alan @altano",
+    "Tobias Koppers @sokra"
   ],
   "description": "handlebars loader module for webpack",
   "dependencies": {
@@ -26,5 +22,23 @@
     "type": "git",
     "url": "git://github.com/altano/handlebars-loader.git"
   },
-  "version": "0.1.7"
+  "version": "0.1.7",
+  "devDependencies": {
+    "mocha": "^1.21.4",
+    "sinon": "^1.10.3"
+  },
+  "bugs": {
+    "url": "https://github.com/altano/handlebars-loader/issues"
+  },
+  "homepage": "https://github.com/altano/handlebars-loader",
+  "main": "index.js",
+  "directories": {
+    "example": "example",
+    "test": "test"
+  },
+  "scripts": {
+    "test": "mocha"
+  },
+  "author": "",
+  "license": "MIT"
 }

--- a/test/helpers/image.js
+++ b/test/helpers/image.js
@@ -1,0 +1,5 @@
+var handlebars = require('handlebars');
+
+module.exports = function (text) {
+  return new handlebars.SafeString('<img src="' + text + '"/>');
+};

--- a/test/lib/WebpackLoaderMock.js
+++ b/test/lib/WebpackLoaderMock.js
@@ -1,0 +1,36 @@
+var fs = require('fs'),
+    path = require('path');
+
+function WebpackLoaderMock (options) {
+  this.context = options.context || '';
+  this.query = options.query;
+  this._asyncCallback = options.async;
+  this._resolveStubs = options.resolveStubs || {};
+}
+
+WebpackLoaderMock.prototype.resolve = function (context, resource, callback) {
+  var stub = this._resolveStubs[resource],
+      fullPath;
+
+  if (stub) {
+    return callback(null, stub);
+  }
+
+  if (context) {
+    // TODO: this is pretty hacky, assuming .js files - if we wanted to really
+    // mock this out, we'd need to do sort of what the loader _actually_ does:
+    // try a bunch of extensions (set via config) until one is found.
+    fullPath = path.join(context, resource + '.js');
+    if (fs.existsSync(fullPath)) {
+      return callback(null, fullPath);
+    }
+  }
+
+  callback(null, null);
+};
+
+WebpackLoaderMock.prototype.async = function () {
+  return this._asyncCallback;
+};
+
+module.exports = WebpackLoaderMock;

--- a/test/partial.handlebars
+++ b/test/partial.handlebars
@@ -1,0 +1,3 @@
+{{#if description}}
+<p>{{description}}</p>
+{{/if}}

--- a/test/simple.handlebars
+++ b/test/simple.handlebars
@@ -1,0 +1,6 @@
+<h1>{{title}}</h1>
+<p>A simple template</p>
+
+{{#if description}}
+<p>{{description}}</p>
+{{/if}}

--- a/test/test.js
+++ b/test/test.js
@@ -1,0 +1,118 @@
+var assert = require('assert'),
+    fs = require('fs'),
+    path = require('path'),
+    sinon = require('sinon'),
+
+    loader = require('../'),
+    WebpackLoaderMock = require('./lib/WebpackLoaderMock');
+
+function applyTemplate(source, options) {
+  var requires = options && options.requireStubs || {},
+      _require = sinon.spy(function (resource) {
+        return requires[resource] || require(resource);
+      }),
+      _module = {};
+
+  (new Function('module', 'require', source))(_module, _require);
+
+  options.test(_module.exports(options.data), _require);
+}
+
+function loadTemplate(templatePath) {
+  return fs.readFileSync(path.join(__dirname, templatePath)).toString();
+}
+
+function testTemplate(loader, template, options, testFn) {
+  var resolveStubs = {};
+
+  for (var k in options.stubs) {
+    resolveStubs[k] = k;
+  }
+
+  loader.call(new WebpackLoaderMock({
+    query: options.query,
+    resolveStubs: resolveStubs,
+    async: function (err, source) {
+      if (err || !source) {
+        throw new Error('Could not generate template');
+      }
+
+      applyTemplate(source, {
+        data: options.data,
+        requireStubs: options.stubs,
+        test: testFn
+      });
+    }
+  }), loadTemplate(template));
+}
+
+describe('handlebars-loader', function () {
+
+  it('should load simple handlebars templates', function (done) {
+    testTemplate(loader, './simple.handlebars', {
+      data: {
+        title: 'This is the title',
+        description: 'This is the description'
+      }
+    }, function (output, require) {
+      assert.ok(output, 'generated output');
+      // There will actually be 1 require for the main handlebars runtime library
+      assert.equal(require.callCount, 1,
+        'should not have required anything extra');
+      done();
+    });
+  });
+
+  it('should convert helpers into require statements', function (done) {
+    testTemplate(loader, './with-helpers.handlebars', {
+      stubs: {
+        'title': function (text) { return 'Title: ' + text; },
+        './description': function (text) { return 'Description: ' + text; }
+      },
+      data: {
+        title: 'This is the title',
+        description: 'This is the description'
+      }
+    }, function (output, require) {
+      assert.ok(output, 'generated output');
+      assert.ok(require.calledWith('title'),
+        'should have loaded helper with module syntax');
+      assert.ok(require.calledWith('./description'),
+        'should have loaded helper with relative syntax');
+      done();
+    });
+  });
+
+  it('should convert partials into require statements', function (done) {
+    testTemplate(loader, './with-partials.handlebars', {
+      stubs: {
+        './partial': require('./partial.handlebars'),
+        'partial': require('./partial.handlebars')
+      },
+      data: {
+        title: 'This is the title',
+        description: 'This is the description'
+      }
+    }, function (output, require) {
+      assert.ok(output, 'generated output');
+      assert.ok(require.calledWith('partial'),
+        'should have loaded partial with module syntax');
+      assert.ok(require.calledWith('./partial'),
+        'should have loaded partial with relative syntax');
+      done();
+    });
+  });
+
+  it('allows specifying additional helper search directories', function (done) {
+    testTemplate(loader, './with-dir-helpers.handlebars', {
+      query: '?helperDirs[]=' + path.join(__dirname, 'helpers'),
+      data: {
+        image: 'http://www.gravatar.com/avatar/205e460b479e2e5b48aec07710c08d50'
+      }
+    }, function (output, require) {
+      assert.ok(output, 'generated output');
+      done();
+    });
+  });
+
+});

--- a/test/with-dir-helpers.handlebars
+++ b/test/with-dir-helpers.handlebars
@@ -1,0 +1,1 @@
+{{image image}}

--- a/test/with-helpers.handlebars
+++ b/test/with-helpers.handlebars
@@ -1,0 +1,5 @@
+{{! using the module lookup syntax ('$') }}
+{{$title title}}
+
+{{! using the relative lookup syntax}}
+{{description description}}

--- a/test/with-partials.handlebars
+++ b/test/with-partials.handlebars
@@ -1,0 +1,7 @@
+<h1>{{title}}</h1>
+
+{{! using module syntax }}
+{{>$partial this}}
+
+{{! using relative syntax }}
+{{>partial this}}


### PR DESCRIPTION
Adds preliminary test coverage via a small mocha suite. Try it out with `npm test`. It works by mocking a webpack loader and ensuring that the proper resources are requested in different scenarios.

Also cleans up the package.json a bit.
