### PR TITLE
Add rootRelative option to specify where helpers/partials resolved from

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ var template = require("./file.handlebars");
 
 ## Details
 
-The loader resolves partials and helpers automatically. They are looked up relative to the current directory or as a module if you prefix with `$`.
+The loader resolves partials and helpers automatically. They are looked up relative to the current directory (this can be modified with the `rootRelative` option) or as a module if you prefix with `$`.
 
 ```handlebars
 A file "/folder/file.handlebars".
@@ -43,6 +43,7 @@ The following query options are supported:
  - *runtime*: Specify the path to the handlebars runtime library. Defaults to look under the local handlebars npm module, i.e. `handlebars/runtime`.
  - *extensions*: Searches for templates with alternate extensions. Defaults are .handlebars, .hbs, and '' (no extension).
  - *inlineRequires*: Defines a regex that identifies strings within helper/partial parameters that should be replaced by inline require statements.
+ - *rootRelative*: When automatically resolving partials and helpers, use an implied root path if none is present. Default = `./`. Setting this to be empty effectively turns off automatically resolving relative handlebars resources for items like `{{helper}}`. `{{./helper}}` will still resolve as expected.
 
 See [`webpack`](https://github.com/webpack/webpack) documentation for more information regarding loaders.
 

--- a/index.js
+++ b/index.js
@@ -21,6 +21,11 @@ module.exports = function(source) {
 		extensions = extensions.split(/[ ,;]/g);
 	}
 
+	var rootRelative = query.rootRelative;
+	if (rootRelative == null) {
+		rootRelative = "./";
+	}
+
 	var foundPartials = {};
 	var foundHelpers = {};
 	var foundUnclearStuff = {};
@@ -101,6 +106,13 @@ module.exports = function(source) {
 			console.log("\nCompilation pass %d", ++compilationPass);
 		}
 
+		function referenceToRequest(ref) {
+			if (/^\$/.test(ref))
+				return ref.substring(1);
+			else
+				return rootRelative + ref;
+		}
+
 		// Need another compiler pass?
 		var needRecompile = false;
 
@@ -115,9 +127,6 @@ module.exports = function(source) {
 
 			// Any additional helper dirs will be added to the searchable contexts
 			if (query.helperDirs) {
-				if (!Array.isArray(query.helperDirs)) {
-					query.helperDirs = [query.helperDirs];
-				}
 				contexts = contexts.concat(query.helperDirs);
 			}
 
@@ -259,10 +268,3 @@ module.exports = function(source) {
 		resolveHelpers();
 	}());
 };
-
-function referenceToRequest(ref) {
-	if (/^\$/.test(ref))
-		return ref.substring(1);
-	else
-		return "./"+ref;
-}


### PR DESCRIPTION
Currently, the loader will always try to automatically resolve helpers/partials relative to the template file's directory when it encounters a tag like `{{title}}`. However, sometimes you may not want it to pull in `./title.js` automatically, because it might not actually be a handlebars helper.

`rootRelative` can now be specified to override this default lookup behavior. Specifying `rootRelative=` on the loader `query` will effectively turn the behavior off entirely, or it can be set to any path you choose.

By default it is set to `./`, maintaining current compatibility.
