### PR TITLE
Properly catch errors during precompilation

### DIFF
--- a/index.js
+++ b/index.js
@@ -117,10 +117,16 @@ module.exports = function(source) {
 		var needRecompile = false;
 
 		// Precompile template
-		var template = hb.precompile(source, {
-			knownHelpersOnly: firstCompile ? false : true,
-			knownHelpers: knownHelpers
-		});
+		var template;
+
+		try {
+			template = hb.precompile(source, {
+				knownHelpersOnly: firstCompile ? false : true,
+				knownHelpers: knownHelpers
+			});
+		} catch (err) {
+			return loaderAsyncCallback(err);
+		}
 
 		var resolve = function(request, type, callback) {
 			var contexts = [loaderApi.context];
@@ -230,7 +236,7 @@ module.exports = function(source) {
 		};
 
 		var resolvePartials = function(err) {
-			if (err) throw err;
+			if (err) return doneResolving(err);
 
 			if (debug) {
 				console.log("Attempting to resolve partials:");
@@ -242,7 +248,7 @@ module.exports = function(source) {
 		};
 
 		var resolveUnclearStuff = function(err) {
-			if (err) throw err;
+			if (err) return resolvePartials(err);
 
 			if (debug) {
 				console.log("Attempting to resolve unclearStuff:");
@@ -254,7 +260,7 @@ module.exports = function(source) {
 		};
 
 		var resolveHelpers = function(err) {
-			if (err) throw err;
+			if (err) throw resolveUnclearStuff(err);
 
 			if (debug) {
 				console.log("Attempting to resolve helpers:");

--- a/test/invalid-syntax-error.handlebars
+++ b/test/invalid-syntax-error.handlebars
@@ -1,0 +1,5 @@
+{{ someVar }}
+
+{{)INVALID STUFFS}}
+
+<div></div>

--- a/test/invalid-unknown-helpers.handlebars
+++ b/test/invalid-unknown-helpers.handlebars
@@ -1,0 +1,5 @@
+{{unknownExistingHelper data}}
+
+{{unknownMissingHelper data}}
+
+<div></div>


### PR DESCRIPTION
If an error happened at certain stages of precompilation, the loader
would throw an error, which would propagate back to webpack and break
recompilation attempts.

The errors should be sent out on the async loader callback - only sync
loaders can throw and have those Errors caught by webpack.
