### PR TITLE
Generate source maps

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@ var handlebars = require("handlebars");
 var async = require("async");
 var util = require("util");
 var path = require("path");
+var semver = require("semver");
 var fastreplace = require('./lib/fastreplace');
 var findNestedRequires = require('./lib/findNestedRequires');
 
@@ -15,6 +16,7 @@ module.exports = function(source) {
 	var loaderApi = this;
 	var query = this.query instanceof Object ? this.query : loaderUtils.parseQuery(this.query);
 	var runtimePath = query.runtime || require.resolve("handlebars/runtime");
+	var srcName = path.basename(this.resourcePath);
 
 	if (!versionCheck(handlebars, require(runtimePath))) {
 		throw new Error('Handlebars compiler version does not match runtime version');
@@ -52,6 +54,7 @@ module.exports = function(source) {
 	}
 
 	var debug = query.debug;
+	var useSrcMap = this.sourceMap && semver.satisfies(handlebars.VERSION, '>=3.0.0');
 
 	var hb = handlebars.create();
 	var JavaScriptCompiler = hb.JavaScriptCompiler;
@@ -135,13 +138,27 @@ module.exports = function(source) {
 
 		// Precompile template
 		var template = '';
+		var srcMap;
 
 		try {
 			if (source) {
-				template = hb.precompile(source, {
+				var precompileOptions = {
 					knownHelpersOnly: firstCompile ? false : true,
 					knownHelpers: knownHelpers
-				});
+				};
+
+				if (useSrcMap) {
+					precompileOptions.srcName = srcName;
+				}
+
+				var result = hb.precompile(source, precompileOptions);
+
+				if (useSrcMap) {
+					template = result.code;
+					srcMap = JSON.parse(result.map);
+				} else {
+					template = result;
+				}
 			}
 		} catch (err) {
 			return loaderAsyncCallback(err);
@@ -250,12 +267,12 @@ module.exports = function(source) {
 			}
 
 			// export as module if template is not blank
-			var slug = template ?
+			var output = template ?
 				'var Handlebars = require(' + JSON.stringify(runtimePath) + ');\n'
 				+ 'module.exports = (Handlebars["default"] || Handlebars).template(' + template + ');' :
 				'module.exports = function(){return "";};';
 
-			loaderAsyncCallback(null, slug);
+			loaderAsyncCallback(null, output, srcMap);
 		};
 
 		var resolvePartials = function(err) {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
   "dependencies": {
     "async": "~0.2.10",
     "fastparse": "^1.0.0",
-    "loader-utils": "0.2.x"
+    "loader-utils": "0.2.x",
+    "semver": "^5.0.3"
   },
   "peerDependencies": {
     "handlebars": ">= 1.3.0 < 5"

--- a/test/lib/WebpackLoaderMock.js
+++ b/test/lib/WebpackLoaderMock.js
@@ -6,6 +6,8 @@ function WebpackLoaderMock (options) {
   this.query = options.query;
   this._asyncCallback = options.async;
   this._resolveStubs = options.resolveStubs || {};
+  this.sourceMap = options.sourceMap;
+  this.resourcePath = options.resourcePath;
 }
 
 WebpackLoaderMock.prototype.resolve = function (context, resource, callback) {

--- a/test/test.js
+++ b/test/test.js
@@ -14,7 +14,7 @@ var assert = require('assert'),
       object: {a: 'a', b: 'b', c: 'c'}
     };
 
-function applyTemplate(source, options) {
+function applyTemplate(source, map, options) {
   var requires = options && options.requireStubs || {},
       _require = sinon.spy(function (resource) {
         return requires[resource] || require(resource);
@@ -23,7 +23,7 @@ function applyTemplate(source, options) {
 
   (new Function('module', 'require', source))(_module, _require);
 
-  options.test(null, _module.exports(options.data), _require);
+  options.test(null, _module.exports(options.data), _require, map);
 }
 
 function loadTemplate(templatePath) {
@@ -39,8 +39,10 @@ function testTemplate(loader, template, options, testFn) {
 
   loader.call(new WebpackLoaderMock({
     query: options.query,
+    sourceMap: options.sourceMap,
     resolveStubs: resolveStubs,
-    async: function (err, source) {
+    resourcePath: template,
+    async: function (err, source, map) {
       if (err) {
         // Proxy errors from loader to test function
         return testFn(err);
@@ -48,7 +50,7 @@ function testTemplate(loader, template, options, testFn) {
         return testFn(new Error('Could not generate template'));
       }
 
-      applyTemplate(source, {
+      applyTemplate(source, map, {
         data: options.data,
         requireStubs: options.stubs,
         test: testFn
@@ -372,6 +374,18 @@ describe('handlebars-loader', function () {
         'should have loaded helper with relative syntax');
       assert.ok(require.calledWith('images/path/to/image'),
         'should have required image path');
+      done();
+    });
+  });
+
+  it('should generate source map', function (done) {
+    testTemplate(loader, './simple.handlebars', {
+      sourceMap: true,
+      data: TEST_TEMPLATE_DATA
+    }, function (err, output, require, map) {
+      assert.ok(map);
+      assert.equal(map.sources.length, 1);
+      assert.equal(map.sources[0], 'simple.handlebars');
       done();
     });
   });


### PR DESCRIPTION
* Activated by the gulp sourceMap boolean.
* Won't try to generate sourceMaps for handlebars versions < 3
* Strips path information, only preserves filename.

Closes #50