### PR TITLE
Extend knownHelpers; Add Alias functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,8 @@ The following query options are supported:
  - *extensions*: Searches for templates with alternate extensions. Defaults are .handlebars, .hbs, and '' (no extension).
  - *inlineRequires*: Defines a regex that identifies strings within helper/partial parameters that should be replaced by inline require statements.
  - *rootRelative*: When automatically resolving partials and helpers, use an implied root path if none is present. Default = `./`. Setting this to be empty effectively turns off automatically resolving relative handlebars resources for items like `{{helper}}`. `{{./helper}}` will still resolve as expected.
- - *knownHelpers*: Array of helpers that are registered at runtime and should not explicitly be required by webpack. This helps with interoperability for libraries like Thorax [helpers](http://thoraxjs.org/api.html#template-helpers).
+ - *alias*: Array of aliases to use when resolving references. Each alias should have a `from` property with a pattern to match, and `to` with the string to insert as a replacement. Example: `alias: [{ from: "^common\/", to: "../../libs/shared" }]` If `require("common/util")` doesn't find a match, the loader will try `require("../../libs/shared/util")`
+ - *knownHelpers*: Array of helpers that are registered at runtime and should not explicitly be required by webpack. This helps with interoperability for libraries like Thorax [helpers](http://thoraxjs.org/api.html#template-helpers). Can be set to `true` to assume all helpers are known and registered at runtime.
  - *debug*: Shows trace information to help debug issues (e.g. resolution of helpers).
 
 See [`webpack`](https://github.com/webpack/webpack) documentation for more information regarding loaders.

--- a/index.js
+++ b/index.js
@@ -29,10 +29,13 @@ module.exports = function(source) {
 		extensions = extensions.split(/[ ,;]/g);
 	}
 
-	var rootRelative = query.rootRelative;
-	if (rootRelative == null) {
-		rootRelative = "./";
-	}
+	var rootRelative = query.rootRelative || "./";
+	var aliases = (query.alias || []).map(function (alias) {
+		return {
+			from: new RegExp(alias.from),
+			to: alias.to
+		};
+	});
 
 	var foundPartials = {};
 	var foundHelpers = {};
@@ -122,12 +125,24 @@ module.exports = function(source) {
 		}
 
 		function referenceToRequest(ref, type) {
-			if (/^\$/.test(ref))
+			if (/^\$/.test(ref)) {
 				return ref.substring(1);
-			else if (type === 'helper' && query.helperDirs && query.helperDirs.length)
+			} else if (type === 'helper' && query.helperDirs && query.helperDirs.length) {
 				return ref;
-			else
-				return rootRelative + ref;
+			} else {
+				var isAliased;
+
+				aliases
+					.filter(function (alias) {
+						return alias.from.test(ref);
+					})
+					.forEach(function (alias) {
+						isAliased = true;
+						ref = ref.replace(alias.from, alias.to);
+					});
+
+				return isAliased ? ref : rootRelative + ref;
+			}
 		}
 
 		// Need another compiler pass?

--- a/index.js
+++ b/index.js
@@ -41,9 +41,12 @@ module.exports = function(source) {
 	var foundHelpers = {};
 	var foundUnclearStuff = {};
 	var knownHelpers = {};
+	var allKnownHelpers = false;
 
 	var queryKnownHelpers = query.knownHelpers;
-	if (queryKnownHelpers) {
+	if (queryKnownHelpers === true) {
+		allKnownHelpers = true;
+	}	else if (queryKnownHelpers) {
 		[].concat(queryKnownHelpers).forEach(function(k) {
 			knownHelpers[k] = true;
 		});
@@ -153,7 +156,7 @@ module.exports = function(source) {
 
 		try {
 			template = hb.precompile(source, {
-				knownHelpersOnly: firstCompile ? false : true,
+				knownHelpersOnly: (allKnownHelpers || firstCompile) ? false : true,
 				knownHelpers: knownHelpers
 			});
 		} catch (err) {


### PR DESCRIPTION
Hi @altano, we're using `handlebars-loader` for our build process at Walmart Labs.  We made a couple of enhancements that were necessary for our use case, and thought we'd offer the PR in case you're interested.

- `knownHelpers` can now take a value of `true`.  When set to `true`, `handlebars-loader` will assume all helpers are known and registered at run-time.
- You can now `alias` paths.  Keys follow regex syntax and match the reference to a helper or partial in a helper.  Values replace the match with the provided value.  This was necessary for us since `handlebars-loader` does not use Webpack to do asset resolution.

Thanks!

(if you're interested, I'll pull down latest master and resolve the conflicts)