### PR TITLE
Add ability to require babel default export for helpers

### DIFF
--- a/index.js
+++ b/index.js
@@ -73,7 +73,7 @@ module.exports = function(source) {
 		}
 		else if (type === "helper") {
 			if (foundHelpers["$" + name]) {
-				return "require(" + JSON.stringify(foundHelpers["$" + name]) + ")";
+				return "__default(require(" + JSON.stringify(foundHelpers["$" + name]) + "))";
 			}
 			foundHelpers["$" + name] = null;
 			return JavaScriptCompiler.prototype.nameLookup.apply(this, arguments);
@@ -252,6 +252,7 @@ module.exports = function(source) {
 			// export as module if template is not blank
 			var slug = template ?
 				'var Handlebars = require(' + JSON.stringify(runtimePath) + ');\n'
+				+ 'function __default(obj) { return obj && (obj.__esModule ? obj["default"] : obj); }\n'
 				+ 'module.exports = (Handlebars["default"] || Handlebars).template(' + template + ');' :
 				'module.exports = function(){return "";};';
 

--- a/test/helpers-babel/description.js
+++ b/test/helpers-babel/description.js
@@ -1,0 +1,9 @@
+"use strict";
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+
+exports.default = function (text) {
+  return "Description " + text;
+};

--- a/test/test.js
+++ b/test/test.js
@@ -375,5 +375,19 @@ describe('handlebars-loader', function () {
       done();
     });
   });
+  
+  it('should be able to use babel6/es6 helpers', function (done) {
+    testTemplate(loader, './with-helpers-babel.handlebars', {
+      query: '?' + JSON.stringify({
+        helperDirs: [
+          path.join(__dirname, 'helpers-babel'),
+        ]
+      }),
+      data: TEST_TEMPLATE_DATA
+    }, function (err, output, require) {
+      assert.ok(output, 'Description Description');
+      done();
+    });
+  });
 
 });

--- a/test/with-helpers-babel.handlebars
+++ b/test/with-helpers-babel.handlebars
@@ -1,0 +1,2 @@
+{{! using the relative lookup syntax}}
+{{./description description}}


### PR DESCRIPTION
In babel version 6 export default doesn't produce `module.exports = exports["default"]` anymore 
(https://github.com/babel/babel/issues/2683 [Babel Changelog](https://github.com/babel/babel/blob/master/CHANGELOG.md#600))