### PR TITLE
Fix relative helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 ### Added
+- Fixed resolving relative helpers on first pass when helper directories are given
 - Your feature here!
 
 ## [1.3.0] - 2016-04-29

--- a/index.js
+++ b/index.js
@@ -131,12 +131,17 @@ module.exports = function(source) {
     }
 
     function referenceToRequest(ref, type) {
-      if (/^\$/.test(ref))
+      if (/^\$/.test(ref)) {
         return ref.substring(1);
-      else if (type === 'helper' && query.helperDirs && query.helperDirs.length)
-        return ref;
-      else
-        return rootRelative + ref;
+      }
+
+      // Use a relative path for helpers if helper directories are given
+      // unless automatic relative helper resolution has been turned off
+      if (type === 'helper' && query.helperDirs && query.helperDirs.length && rootRelative !== '') {
+        return './' + ref;
+      }
+
+      return rootRelative + ref;
     }
 
     // Need another compiler pass?

--- a/test/test.js
+++ b/test/test.js
@@ -345,11 +345,11 @@ describe('handlebars-loader', function () {
       data: TEST_TEMPLATE_DATA
     }, function (err, output, require) {
       assert.ok(output, 'generated output');
-      assert.ok(require.calledWith('image'),
-        'should have loaded helper');
+      assert.ok(!require.calledWith('image'),
+        'should not have loaded helper with module syntax');
 
-      assert.ok(require.calledWith('nested/quotify'),
-        'should have loaded nested helper');
+      assert.ok(!require.calledWith('nested/quotify'),
+        'should not have loaded nested helper with module syntax');
 
       assert.ok(require.calledWith('relative-partial'),
         'should have loaded partial with module syntax');

--- a/test/with-relative-root.handlebars
+++ b/test/with-relative-root.handlebars
@@ -1,7 +1,5 @@
 {{image image}}
 
-{{./image image}}
-
 {{[nested/quotify] title}}
 
 {{>$relative-partial this}}


### PR DESCRIPTION
I found an issues that was introduced in #35 where on the first pass of the compiler, if helperDirs are given, the helper is resolved as a module, not a relative helper. This seems to be caused by `referenceToRequest()` returning the ref without prepending a relative path.

On the second pass of the compiler, the helper seems to get picked up as `'unclearStuff'` and gets resolved properly which hides the underlying issue.

I've updated the test to ensure that the relative helper isn't resolved as a module. Then changed the code to get the test passing by always prepending a relative path. I added the check for `rootRelative.length` in the case that automatic resolving of helpers is turned off.