### PR TITLE
add option to allow absolutely resolve partials

### DIFF
--- a/index.js
+++ b/index.js
@@ -154,7 +154,9 @@ module.exports = function(source) {
 			if (query.helperDirs) {
 				contexts = contexts.concat(query.helperDirs);
 			}
-
+			if (query.partialDirs) {
+				contexts = contexts.concat(query.partialDirs);
+			}
 			var resolveWithContexts = function() {
 				var context = contexts.shift();
 


### PR DESCRIPTION
Hi @altano ,  
we are going to migrate requireJS to webpack. but we have a tons of handlebar partials defined using absolute path. It will be really convenient that we could have a config option to allow handlebar loader to resolve partials with absolute path. Could you add this feature in. Thanks for your time. 

Best Regards, 

-Larry