### PR TITLE
Make handlebars partial blocks work

### DIFF
--- a/examples/basic/app.js
+++ b/examples/basic/app.js
@@ -4,6 +4,7 @@ document.addEventListener("DOMContentLoaded", function() {
 	var div = document.createElement('div');
 	div.innerHTML = bookListingTemplate({
 		username: "test",
+		info: "Your books are due next Tuesday",
 		books: [
 			{ title: "A book", synopsis: "With a description" },
 			{ title: "Another book", synopsis: "From a very good author" },

--- a/examples/basic/book-listing.handlebars
+++ b/examples/basic/book-listing.handlebars
@@ -1,4 +1,7 @@
 <h1>{{username}}</h1>
+{{#> info-box}}
+<p>{{info}}</p>
+{{/info-box}}
 <div>
   {{#books}}{{> book}}{{/books}}
 </div>

--- a/examples/basic/info-box.handlebars
+++ b/examples/basic/info-box.handlebars
@@ -1,0 +1,4 @@
+<div class="info-box">
+  <strong>You've got info:</strong>
+  {{> @partial-block}}
+</div>

--- a/index.js
+++ b/index.js
@@ -70,6 +70,10 @@ module.exports = function(source) {
 			console.log("nameLookup %s %s %s", parent, name, type);
 		}
 		if (type === "partial") {
+			if (name[0] == '@') {
+				// this is a built in partial, no need to require it
+				return JavaScriptCompiler.prototype.nameLookup.apply(this, arguments);
+			}
 			if (foundPartials["$" + name]) {
 				return "require(" + JSON.stringify(foundPartials["$" + name]) + ")";
 			}


### PR DESCRIPTION
I noticed that using the syntax

  {{> @partial-block}}

in my handlebars templates, as documented in
http://handlebarsjs.com/partials.html, caused the loader to throw the
following error:

  Module build failed: Error: Partial '@partial-block' not found

The changes in this pull request seem to fix that problem.