### PR TITLE
Improve portability tweaks

### DIFF
--- a/index.js
+++ b/index.js
@@ -289,7 +289,7 @@ module.exports = function(source) {
 			}
 
 			// Resolve path for each partial
-			async.forEach(Object.keys(foundPartials), resolvePartialsIterator, doneResolving);
+			async.each(Object.keys(foundPartials), resolvePartialsIterator, doneResolving);
 		};
 
 		var resolveUnclearStuff = function(err) {
@@ -301,7 +301,7 @@ module.exports = function(source) {
 			}
 
 			// Check for each found unclear item if it is a helper
-			async.forEach(Object.keys(foundUnclearStuff), resolveUnclearStuffIterator, resolvePartials);
+			async.each(Object.keys(foundUnclearStuff), resolveUnclearStuffIterator, resolvePartials);
 		};
 
 		var resolveHelpers = function(err) {
@@ -313,7 +313,7 @@ module.exports = function(source) {
 			}
 
 			// Resolve path for each helper
-			async.forEach(Object.keys(foundHelpers), resolveHelpersIterator, resolveUnclearStuff);
+			async.each(Object.keys(foundHelpers), resolveHelpersIterator, resolveUnclearStuff);
 		};
 
 		resolveHelpers();

--- a/index.js
+++ b/index.js
@@ -280,40 +280,29 @@ module.exports = function(source) {
 			loaderAsyncCallback(null, slug);
 		};
 
-		var resolvePartials = function(err) {
-			if (err) return doneResolving(err);
+        var resolveItems = function(err, type, items, iterator, callback) {
+            if (err) return callback(err);
+
+            var itemKeys = Object.keys(items);
 
 			if (debug) {
-				console.log("Attempting to resolve partials:");
-				console.log(foundPartials);
+				console.log("Attempting to resolve ", type, ":", itemKeys);
 			}
 
-			// Resolve path for each partial
-			async.each(Object.keys(foundPartials), resolvePartialsIterator, doneResolving);
+			// Resolve path for each item
+			async.each(itemKeys, iterator, callback);
+        }
+
+		var resolvePartials = function(err) {
+            resolveItems(err, 'partials', foundPartials, resolvePartialsIterator, doneResolving);
 		};
 
 		var resolveUnclearStuff = function(err) {
-			if (err) return resolvePartials(err);
-
-			if (debug) {
-				console.log("Attempting to resolve unclearStuff:");
-				console.log(foundUnclearStuff);
-			}
-
-			// Check for each found unclear item if it is a helper
-			async.each(Object.keys(foundUnclearStuff), resolveUnclearStuffIterator, resolvePartials);
+            resolveItems(err, 'unclearStuff', foundUnclearStuff, resolveUnclearStuffIterator, resolvePartials);
 		};
 
 		var resolveHelpers = function(err) {
-			if (err) throw resolveUnclearStuff(err);
-
-			if (debug) {
-				console.log("Attempting to resolve helpers:");
-				console.log(foundHelpers);
-			}
-
-			// Resolve path for each helper
-			async.each(Object.keys(foundHelpers), resolveHelpersIterator, resolveUnclearStuff);
+            resolveItems(err, 'helpers', foundHelpers, resolveHelpersIterator, resolveUnclearStuff);
 		};
 
 		resolveHelpers();

--- a/index.js
+++ b/index.js
@@ -280,10 +280,10 @@ module.exports = function(source) {
 			loaderAsyncCallback(null, slug);
 		};
 
-        var resolveItems = function(err, type, items, iterator, callback) {
-            if (err) return callback(err);
+		var resolveItems = function(err, type, items, iterator, callback) {
+			if (err) return callback(err);
 
-            var itemKeys = Object.keys(items);
+			var itemKeys = Object.keys(items);
 
 			if (debug) {
 				console.log("Attempting to resolve ", type, ":", itemKeys);
@@ -291,18 +291,18 @@ module.exports = function(source) {
 
 			// Resolve path for each item
 			async.each(itemKeys, iterator, callback);
-        }
+		}
 
 		var resolvePartials = function(err) {
-            resolveItems(err, 'partials', foundPartials, resolvePartialsIterator, doneResolving);
+			resolveItems(err, 'partials', foundPartials, resolvePartialsIterator, doneResolving);
 		};
 
 		var resolveUnclearStuff = function(err) {
-            resolveItems(err, 'unclearStuff', foundUnclearStuff, resolveUnclearStuffIterator, resolvePartials);
+			resolveItems(err, 'unclearStuff', foundUnclearStuff, resolveUnclearStuffIterator, resolvePartials);
 		};
 
 		var resolveHelpers = function(err) {
-            resolveItems(err, 'helpers', foundHelpers, resolveHelpersIterator, resolveUnclearStuff);
+			resolveItems(err, 'helpers', foundHelpers, resolveHelpersIterator, resolveUnclearStuff);
 		};
 
 		resolveHelpers();

--- a/index.js
+++ b/index.js
@@ -169,7 +169,7 @@ module.exports = function(source) {
 
 				var traceMsg;
 				if (debug) {
-					traceMsg = path.normalize(context + "\\" + request);
+					traceMsg = path.normalize(path.join(context, request));
 					console.log("Attempting to resolve %s %s", type, traceMsg);
 					console.log("request=%s", request);
 				}

--- a/index.js
+++ b/index.js
@@ -225,7 +225,7 @@ module.exports = function(source) {
 			// Try every extension for partials
 			var i = 0;
 			(function tryExtension() {
-				if (i > extensions.length) {
+				if (i >= extensions.length) {
 					var errorMsg = util.format("Partial '%s' not found", partial.substr(1));
 					return partialCallback(new Error(errorMsg));
 				}


### PR DESCRIPTION
1. Changed async.forEach to async.each as it is deprecated and will eventually be an upgrade issue.
2. Remove unnecessary iteration which produced 'partialundefined' as a final check, rather than empty.
3. Used path to join file structure for debugging messages.
4. Remove redundant code and reuse.