### PR TITLE
Support `preventIndent` option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,9 @@
 # Change Log
 
 ## [Unreleased]
- - New `partialDirs` query option allows specifying additional directories to be searched for partials. Thank you @lostthetrail.
+- New `partialDirs` query option allows specifying additional directories to be searched for partials. Thank you @lostthetrail.
+- New `preventIndent` query option to avoid nested partials adding whitespace to
+  `textarea` and `pre` elements.
 
 ## [1.2.0] - 2016-03-15
 

--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ The following query options are supported:
  - *exclude*: Defines a regex that will exclude paths from resolving. This can be used to prevent helpers from being resolved to modules in the `node_modules` directory.
  - *debug*: Shows trace information to help debug issues (e.g. resolution of helpers).
  - *partialDirs*: Defines additional directories to be searched for partials. Allows partials to be defined in a directory and used globally without relative paths. See [example](https://github.com/altano/handlebars-loader/tree/master/examples/partialDirs)
+ - *preventIndent*: Prevent partials from being indented inside their parent template.
 
 See [`webpack`](https://github.com/webpack/webpack) documentation for more information regarding loaders.
 

--- a/index.js
+++ b/index.js
@@ -149,7 +149,8 @@ module.exports = function(source) {
 			if (source) {
 				template = hb.precompile(source, {
 					knownHelpersOnly: firstCompile ? false : true,
-					knownHelpers: knownHelpers
+					knownHelpers: knownHelpers,
+					preventIndent: query.preventIndent
 				});
 			}
 		} catch (err) {


### PR DESCRIPTION
`preventIndent` can solve a lot of problems with extra whitespace in `pre` and `textarea` tags.

See https://github.com/wycats/handlebars.js/issues/858