### PR TITLE
Extend debug mode with source file template info

### DIFF
--- a/index.js
+++ b/index.js
@@ -158,7 +158,7 @@ module.exports = function(source) {
           //add source(file) of the template
           sourceToCompile = '\n<!-- START: ' + resourcePath + '  -->\n' + source + '\n<!-- END: ' + resourcePath + '  -->\n';
         }
-        template = hb.precompile(source, {
+        template = hb.precompile(sourceToCompile, {
           knownHelpersOnly: firstCompile ? false : true,
           knownHelpers: knownHelpers,
           preventIndent: query.preventIndent

--- a/index.js
+++ b/index.js
@@ -156,7 +156,7 @@ module.exports = function(source) {
         var sourceToCompile = source;
         if (debug) {
           //add source(file) of the template
-          sourceToCompile = '\n<!-- START: ' + resourcePath + '  -->\n' + source + '\n<!-- END: ' + resource + '  -->\n';
+          sourceToCompile = '\n<!-- START: ' + resourcePath + '  -->\n' + source + '\n<!-- END: ' + resourcePath + '  -->\n';
         }
         template = hb.precompile(source, {
           knownHelpersOnly: firstCompile ? false : true,

--- a/index.js
+++ b/index.js
@@ -13,6 +13,7 @@ function versionCheck(hbCompiler, hbRuntime) {
 module.exports = function(source) {
   if (this.cacheable) this.cacheable();
   var loaderApi = this;
+  var resourcePath = this.resource;
   var query = this.query instanceof Object ? this.query : loaderUtils.parseQuery(this.query);
   var runtimePath = query.runtime || require.resolve("handlebars/runtime");
 
@@ -152,6 +153,11 @@ module.exports = function(source) {
 
     try {
       if (source) {
+        var sourceToCompile = source;
+        if (debug) {
+          //add source(file) of the template
+          sourceToCompile = '\n<!-- START: ' + resourcePath + '  -->\n' + source + '\n<!-- END: ' + resource + '  -->\n';
+        }
         template = hb.precompile(source, {
           knownHelpersOnly: firstCompile ? false : true,
           knownHelpers: knownHelpers,


### PR DESCRIPTION
In complex app sometimes is  problematic with finding source template which is responsible for some HTML. We can add file info with debug mode like

```
<-- START option/views/action.hbs -->
some html
<-- END option/views/action.hbs -->
```
