### PR TITLE
Expose compat flag to query options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 ### Added
 - Fixed resolving relative helpers on first pass when helper directories are given
 - Added `ignorePartials` option to skip automatic lookup/bundling of partials
+- Added `compat` option to enable Mustache lookup compatibility.
 - Your feature here!
 
 ## [1.3.0] - 2016-04-29

--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ The following query options are supported:
  - *partialDirs*: Defines additional directories to be searched for partials. Allows partials to be defined in a directory and used globally without relative paths. See [example](https://github.com/altano/handlebars-loader/tree/master/examples/partialDirs)
  - *preventIndent*: Prevent partials from being indented inside their parent template.
  - *ignorePartials*: Prevents partial references from being fetched and bundled. Useful for manually loading partials at runtime
+ - *compat*: Enables recursive field lookup for Mustache compatibility. See the Handlebars.js [documentation](https://github.com/wycats/handlebars.js#differences-between-handlebarsjs-and-mustache) for more information.
 
 See [`webpack`](https://github.com/webpack/webpack) documentation for more information regarding loaders.
 

--- a/index.js
+++ b/index.js
@@ -155,7 +155,8 @@ module.exports = function(source) {
         template = hb.precompile(source, {
           knownHelpersOnly: firstCompile ? false : true,
           knownHelpers: knownHelpers,
-          preventIndent: query.preventIndent
+          preventIndent: query.preventIndent,
+          compat: query.compat ? true : false
         });
       }
     } catch (err) {


### PR DESCRIPTION
This allows the developer to set Handlebars into Mustache-compatibility
mode.

Fixes #100.