### PR TITLE
Allow custom partialResolver function #103

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@
 - Added `ignorePartials` option to skip automatic lookup/bundling of partials
 - Added `compat` option to enable Mustache lookup compatibility.
 - Your feature here!
+- Added `config` option to query so that configs can be specified in webpack
+  config object or the loader query. Defaults to `handlebarsLoader`
+- Added `partialResolver` config option to override the default partial
+  resolution
+
+### Fixed
+- Previously, if a partial name began with an `@`, it was ignored and treated
+  as an internal to handlebars partial. Now that checks specifically for
+  partials named `@partial-block` so that `{{> @a/b/c.hbs }}` is a valid partial reference
 
 ## [1.3.0] - 2016-04-29
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,8 @@ A file "/folder/file.handlebars".
 {{../helper}} {{$module/helper}} are resolved similarly to partials.
 ```
 
-The following query options are supported:
+The following query (or config) options are supported:
+
  - *helperDirs*: Defines additional directories to be searched for helpers. Allows helpers to be defined in a directory and used globally without relative paths. You must surround helpers in subdirectories with brackets (Handlerbar helper identifiers can't have forward slashes without this). See [example](https://github.com/altano/handlebars-loader/tree/master/examples/helperDirs)
  - *runtime*: Specify the path to the handlebars runtime library. Defaults to look under the local handlebars npm module, i.e. `handlebars/runtime`.
  - *extensions*: Searches for templates with alternate extensions. Defaults are .handlebars, .hbs, and '' (no extension).
@@ -57,6 +58,16 @@ The following query options are supported:
  - *preventIndent*: Prevent partials from being indented inside their parent template.
  - *ignorePartials*: Prevents partial references from being fetched and bundled. Useful for manually loading partials at runtime
  - *compat*: Enables recursive field lookup for Mustache compatibility. See the Handlebars.js [documentation](https://github.com/wycats/handlebars.js#differences-between-handlebarsjs-and-mustache) for more information.
+ - *config*: Tells the loader where to look in the webpack config for configurations for this loader. Defaults to `handlebarsLoader`.
+ - *config.partialResolver* You can specify a function to use for resolving partials. To do so, add to your webpack config:
+    ```js
+    handlebarsLoader: {
+        partialResolver: function(partial, callback){
+            // should pass the partial's path on disk to
+            // to the callback. Callback accepts (err, locationOnDisk)
+        }
+    }
+    ```
 
 See [`webpack`](https://github.com/webpack/webpack) documentation for more information regarding loaders.
 

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
   "dependencies": {
     "async": "~0.2.10",
     "fastparse": "^1.0.0",
-    "loader-utils": "0.2.x"
+    "loader-utils": "0.2.x",
+    "object-assign": "^4.1.0"
   },
   "peerDependencies": {
     "handlebars": ">= 1.3.0 < 5"

--- a/test/lib/WebpackLoaderMock.js
+++ b/test/lib/WebpackLoaderMock.js
@@ -4,6 +4,7 @@ var fs = require('fs'),
 function WebpackLoaderMock (options) {
   this.context = options.context || '';
   this.query = options.query;
+  this.options = options.options || {};
   this._asyncCallback = options.async;
   this._resolveStubs = options.resolveStubs || {};
 }


### PR DESCRIPTION
- fix partial checks to allow for @ in partial name
- webpack config can now contain `handlebarsLoader`
- loader query can now contain `config` to override `handlebarsLoader`
- unit tests that custom resolver is invoked
- unit tests for config override