### PR TITLE
Prevent too many chunks display in webpack dev output

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,7 +30,7 @@ module.exports = function(source) {
   if (this.cacheable) this.cacheable();
   var loaderApi = this;
   var query = getLoaderConfig(loaderApi);
-  var runtimePath = query.runtime || require.resolve("handlebars/runtime");
+  var runtimePath = query.runtime || require.resolve("handlebars/dist/handlebars.runtime");
 
   if (!versionCheck(handlebars, require(runtimePath))) {
     throw new Error('Handlebars compiler version does not match runtime version');


### PR DESCRIPTION
Change `require.resolve("handlebars/runtime")` to `require.resolve("handlebars/dist/handlebars.runtime")`

before:
![image](https://cloud.githubusercontent.com/assets/9346008/19035772/416b33d8-899e-11e6-9c1c-cb1aa608a5ae.png)

after:
![image](https://cloud.githubusercontent.com/assets/9346008/19035518/7b2c3f56-899c-11e6-827d-b7c2a6c71f95.png)
