### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ A [handlebars](http://handlebarsjs.com) template loader for [webpack](https://gi
 {
   ...
   module: {
-    loaders: [
+    rules: [
       ...
       { test: /\.handlebars$/, loader: "handlebars-loader" }
     ]


### PR DESCRIPTION
Hi! webpack 2 is out. I've migrated your docs to new naming convention.

https://webpack.js.org/guides/migrating/#module-loaders-is-now-module-rules