### PR TITLE
Feature/helper resolver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@
 ### Added
 - Your feature here!
 
+## [1.4.1] - 2017-04-18
+
+### Added
+- Added `helperResolver` config option to override the default helper resolution
+
 ## [1.4.0] - 2016-09-02
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,11 +3,6 @@
 ## [Unreleased]
 
 ### Added
-- Your feature here!
-
-## [1.4.1] - 2017-04-18
-
-### Added
 - Added `helperResolver` config option to override the default helper resolution
 
 ## [1.4.0] - 2016-09-02

--- a/README.md
+++ b/README.md
@@ -74,7 +74,17 @@ The following query (or config) options are supported:
         }
     }
     ```
-
+- *config.helperResolver* You can specify a function to use for resolving helpers. To do so, add to your webpack config:
+    ```js
+    handlebarsLoader: {
+        helperResolver: function(helper, callback){
+            // should pass the helper's path on disk to
+            // to the callback if one was find for the given parameter.
+            // Callback accepts (err, locationOnDisk)
+            // Otherwise just call the callback without any arguments
+        }
+    }
+    ```
 See [`webpack`](https://github.com/webpack/webpack) documentation for more information regarding loaders.
 
 ## Full examples

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ The following query (or config) options are supported:
     ```js
     handlebarsLoader: {
         partialResolver: function(partial, callback){
-            // should pass the partial's path on disk to
+            // should pass the partial's path on disk
             // to the callback. Callback accepts (err, locationOnDisk)
         }
     }
@@ -78,8 +78,8 @@ The following query (or config) options are supported:
     ```js
     handlebarsLoader: {
         helperResolver: function(helper, callback){
-            // should pass the helper's path on disk to
-            // to the callback if one was find for the given parameter.
+            // should pass the helper's path on disk
+            // to the callback if one was found for the given parameter.
             // Callback accepts (err, locationOnDisk)
             // Otherwise just call the callback without any arguments
         }

--- a/index.js
+++ b/index.js
@@ -291,7 +291,13 @@ module.exports = function(source) {
       if (foundHelpers[helper]) return helperCallback();
       var request = referenceToRequest(helper.substr(1), 'helper');
 
-      resolve(request, 'helper', function(err, result) {
+      var defaultHelperResolver = function(request, callback){
+        return resolve(request, 'helper', callback);
+      };
+
+      var helperResolver = query.helperResolver || defaultHelperResolver;
+
+      helperResolver(request, function(err, result) {
         if (!err && result) {
           knownHelpers[helper.substr(1)] = true;
           foundHelpers[helper] = result;

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "type": "git",
     "url": "git://github.com/pcardune/handlebars-loader.git"
   },
-  "version": "1.4.0",
+  "version": "1.4.1",
   "devDependencies": {
     "coveralls": "^2.11.8",
     "eslint": "^2.8.0",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "type": "git",
     "url": "git://github.com/pcardune/handlebars-loader.git"
   },
-  "version": "1.4.1",
+  "version": "1.4.0",
   "devDependencies": {
     "coveralls": "^2.11.8",
     "eslint": "^2.8.0",

--- a/test/test.js
+++ b/test/test.js
@@ -173,6 +173,51 @@ describe('handlebars-loader', function () {
     'handlebarsLoaderOverride'
   );
 
+  var helperResolverOverride = function helperResolverOverride(request, cb){
+    switch(request) {
+    case './image':
+      cb(null, './helpers/image.js');
+      break;
+    case './json':
+      cb(null, './helpers2/json.js');
+      break;
+    default:
+      cb();
+    }
+  };
+
+  var testHelperResolver = function testHelperResolver(expectation, options, config){
+    it(expectation, function (done) {
+      testTemplate(loader, './with-dir-helpers-multiple.handlebars', {
+        query: {
+          config: config
+        },
+        options: options,
+        data: TEST_TEMPLATE_DATA
+      }, function (err, output, require) {
+        assert.ok(output, 'generated output');
+        done();
+      });
+    });
+  };
+
+  testHelperResolver(
+    'should use the helperResolver if specified', {
+      handlebarsLoader: {
+        helperResolver: helperResolverOverride
+      }
+    }
+  );
+
+  testHelperResolver(
+    'honors the config query option when finding the helperResolver', {
+      handlebarsLoaderOverride: {
+        helperResolver: helperResolverOverride
+      }
+    },
+    'handlebarsLoaderOverride'
+  );
+
   it('allows specifying additional helper search directory', function (done) {
     testTemplate(loader, './with-dir-helpers.handlebars', {
       query: '?helperDirs[]=' + path.join(__dirname, 'helpers'),


### PR DESCRIPTION
Added `helperResolver` config option to override the default helper resolution.

This config option is implemented in the same way the `partialResolver` is implemented and was added for the same reasons.