### PR TITLE
Adds config to pass options to handlebars precompile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Added
 - Added `ignoreHelpers` option to skip automatic lookup/bundling of helpers
+- Added `precompileOptions` to pass options to handlebars precompile
+- Your feature here!
 
 ## [1.5.0] - 2017-04-20
 
@@ -19,7 +21,6 @@
 - Fixed resolving relative helpers on first pass when helper directories are given
 - Added `ignorePartials` option to skip automatic lookup/bundling of partials
 - Added `compat` option to enable Mustache lookup compatibility.
-- Your feature here!
 - Added `config` option to query so that configs can be specified in webpack
   config object or the loader query. Defaults to `handlebarsLoader`
 - Added `partialResolver` config option to override the default partial

--- a/README.md
+++ b/README.md
@@ -61,10 +61,9 @@ The following query (or config) options are supported:
  - *exclude*: Defines a regex that will exclude paths from resolving. This can be used to prevent helpers from being resolved to modules in the `node_modules` directory.
  - *debug*: Shows trace information to help debug issues (e.g. resolution of helpers).
  - *partialDirs*: Defines additional directories to be searched for partials. Allows partials to be defined in a directory and used globally without relative paths. See [example](https://github.com/altano/handlebars-loader/tree/master/examples/partialDirs)
- - *preventIndent*: Prevent partials from being indented inside their parent template.
  - *ignorePartials*: Prevents partial references from being fetched and bundled. Useful for manually loading partials at runtime.
  - *ignoreHelpers*: Prevents helper references from being fetched and bundled. Useful for manually loading helpers at runtime.
- - *compat*: Enables recursive field lookup for Mustache compatibility. See the Handlebars.js [documentation](https://github.com/wycats/handlebars.js#differences-between-handlebarsjs-and-mustache) for more information.
+ - *precompileOptions*: Options passed to handlebars precompile. See the Handlebars.js [documentation](http://handlebarsjs.com/reference.html#base-precompile) for more information.
  - *config*: Tells the loader where to look in the webpack config for configurations for this loader. Defaults to `handlebarsLoader`.
  - *config.partialResolver* You can specify a function to use for resolving partials. To do so, add to your webpack config:
     ```js


### PR DESCRIPTION
This allows passing all current and future handlebars precompile options through the loader config. This seems like a cleaner approach to adding them piecemeal. I've left support for the current options `preventIndent` and `compat` so that this isn't a breaking change. These can be removed for the next major version release.