### PR TITLE
Make loader aware of "internal" partials

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,8 @@
 
 ## [Unreleased]
 
-### Added
-- Your feature here!
+### Fixed
+- Fixed resolving of inline partials and partial blocks with failover content (#106, #135)
 
 ## [1.6.0] - 2017-09-01 ##
 

--- a/index.js
+++ b/index.js
@@ -318,8 +318,8 @@ module.exports = function(source) {
             visitor.accept(ast);
 
             if (
-              visitor.inlineBlocks.indexOf(request !== -1) ||
-              visitor.partialBlocks.indexOf(request !== -1)
+              visitor.inlineBlocks.indexOf(request) !== -1 ||
+              visitor.partialBlocks.indexOf(request) !== -1
             ) {
               return partialCallback();
             } else {

--- a/index.js
+++ b/index.js
@@ -26,23 +26,6 @@ function getLoaderConfig(loaderContext) {
   return assign({}, config, query);
 }
 
-/**
- * Custom error constructor.
- *
- * @param {String} message
- * @param {Object} data
- * */
-function CustomError(message, data) {
-  this.name = 'CustomError';
-  this.message = message;
-  this.stack = (new Error()).stack;
-  this.data = data;
-  if (Error.captureStackTrace) {
-    Error.captureStackTrace(this, CustomError);
-  }
-}
-CustomError.prototype = new Error();
-
 module.exports = function(source) {
   if (this.cacheable) this.cacheable();
   var loaderApi = this;
@@ -305,7 +288,7 @@ module.exports = function(source) {
       (function tryExtension() {
         if (i >= extensions.length) {
           var errorMsg = util.format("Partial '%s' not found", request);
-          return callback(new CustomError(errorMsg, {request: request}));
+          return callback(new Error(errorMsg));
         }
         var extension = extensions[i++];
 
@@ -331,13 +314,12 @@ module.exports = function(source) {
         partialResolver(request, function(err, resolved){
           if(err) {
             var visitor = new InternalBlocksVisitor();
-            var errPartialName = err.data.request.substring(err.data.request.lastIndexOf('/') + 1);
 
             visitor.accept(ast);
 
             if (
-              visitor.inlineBlocks.indexOf(errPartialName !== -1) ||
-              visitor.partialBlocks.indexOf(errPartialName !== -1)
+              visitor.inlineBlocks.indexOf(request !== -1) ||
+              visitor.partialBlocks.indexOf(request !== -1)
             ) {
               return partialCallback();
             } else {

--- a/test/test.js
+++ b/test/test.js
@@ -542,4 +542,18 @@ describe('handlebars-loader', function () {
     });
   });
 
+  it('should use failover content of the partial block if it refers to non-existent partial', function (done) {
+    testTemplate(loader, './with-partial-block.handlebars', {}, function (err, output, require) {
+      assert.ok(output, 'generated output');
+      done();
+    });
+  });
+
+  it('should recognize and render inline partials', function (done) {
+    testTemplate(loader, './with-inline-partial.handlebars', {}, function (err, output, require) {
+      assert.ok(output, 'generated output');
+      done();
+    });
+  });
+
 });

--- a/test/with-inline-partial.handlebars
+++ b/test/with-inline-partial.handlebars
@@ -1,0 +1,5 @@
+{{#*inline "printFoo"}}
+  Foo
+{{/inline}}
+
+{{> printFoo}}

--- a/test/with-partial-block.handlebars
+++ b/test/with-partial-block.handlebars
@@ -1,0 +1,3 @@
+{{#> non-existent}}
+  <div>Failover</div>
+{{/non-existent}}


### PR DESCRIPTION
When partial is failing to be resolved there is an error thrown [here](https://github.com/pcardune/handlebars-loader/blob/master/index.js#L289), which  interferes with the use of inline partials and failover content of partial blocks (#106, #135 ). Currently, ```handlebars-loader``` considers any partial names as external partials. But some partials with names not necessarily should be external (i.e. inline partials), or it may be acceptable to not have a resolved partial by this name if it is a partial block (which always has failover content). 

I used [AST Visitor](https://github.com/wycats/handlebars.js/blob/master/docs/compiler-api.md#ast-visitor) to save names of any partial blocks and ```inline``` decorators in the current template. In case of resolve error, I check if the name of a partial from failed ```request``` is the one of those saved names and if that is the case I proceed with ```return partialCallback();``` so that Handlebars can do all remaining work. In other case I pass error along as usual