### PR TITLE
Replaced loaderContext.options with loaderContext.rootContext for upcoming Webpack 4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### Fixed
+- Replaced `loaderContext.options` with `loaderContext.rootContext` to work with upcoming Webpack 4
 - Fixed resolving of inline partials and partial blocks with failover content (#106, #135)
 
 ## [1.6.0] - 2017-09-01 ##

--- a/index.js
+++ b/index.js
@@ -21,7 +21,7 @@ function versionCheck(hbCompiler, hbRuntime) {
 function getLoaderConfig(loaderContext) {
   var query = loaderUtils.getOptions(loaderContext) || {};
   var configKey = query.config || 'handlebarsLoader';
-  var config = loaderContext.options[configKey] || {};
+  var config = loaderContext.rootContext[configKey] || {};
   delete query.config;
   return assign({}, config, query);
 }

--- a/index.js
+++ b/index.js
@@ -21,7 +21,7 @@ function versionCheck(hbCompiler, hbRuntime) {
 function getLoaderConfig(loaderContext) {
   var query = loaderUtils.getOptions(loaderContext) || {};
   var configKey = query.config || 'handlebarsLoader';
-  var config = loaderContext.rootContext[configKey] || {};
+  var config = (loaderContext.rootContext ? loaderContext.rootContext[configKey] : loaderContext.options[configKey]) || {};
   delete query.config;
   return assign({}, config, query);
 }

--- a/test/lib/WebpackLoaderMock.js
+++ b/test/lib/WebpackLoaderMock.js
@@ -4,7 +4,7 @@ var fs = require('fs'),
 function WebpackLoaderMock (options) {
   this.context = options.context || '';
   this.query = options.query;
-  this.options = options.options || {};
+  this.rootContext = options.rootContext || {};
   this._asyncCallback = options.async;
   this._resolveStubs = options.resolveStubs || {};
 }

--- a/test/test.js
+++ b/test/test.js
@@ -40,7 +40,7 @@ function testTemplate(loader, template, options, testFn) {
 
   loader.call(new WebpackLoaderMock({
     query: options.query,
-    options: options.options || {},
+    rootContext: options.rootContext || {},
     resolveStubs: resolveStubs,
     async: function (err, source) {
       if (err) {
@@ -143,7 +143,7 @@ describe('handlebars-loader', function () {
         query: {
           config: config
         },
-        options: options,
+        rootContext: options,
         data: TEST_TEMPLATE_DATA
       }, function (err, output, require) {
         assert.ok(output, 'generated output');
@@ -192,7 +192,7 @@ describe('handlebars-loader', function () {
         query: {
           config: config
         },
-        options: options,
+        rootContext: options,
         data: TEST_TEMPLATE_DATA
       }, function (err, output, require) {
         assert.ok(output, 'generated output');


### PR DESCRIPTION
Webpack 4 removes `loaderContext.options` and adds `loaderContext.rootContext` in return: https://github.com/webpack/webpack/releases/tag/v4.0.0-beta.0