### PR TITLE
Clarify that webpack 4 change is not breaking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 ## [1.7.0] - 2018-03-20
 
 ### Fixed
-- Replaced `loaderContext.options` with `loaderContext.rootContext` to work with upcoming Webpack 4
+- Use `loaderContext.rootContext` instead of `loaderContext.options` when used with Webpack 4
 - Fixed resolving of inline partials and partial blocks with failover content (#106, #135)
 
 ## [1.6.0] - 2017-09-01 ##


### PR DESCRIPTION
When I read this I was worried it would break webpack 3,
but looking at the commit history, it looks like this was done
in a backwards-compatible way.

See 95d050e6c7019f95e854cb9f075e81500b5aa9cf