### PR TITLE
Fix: use stringifyRequest instead of absolute paths in loader output

### DIFF
--- a/index.js
+++ b/index.js
@@ -92,14 +92,14 @@ module.exports = function(source) {
         return JavaScriptCompiler.prototype.nameLookup.apply(this, arguments);
       }
       if (foundPartials["$" + name]) {
-        return "require(" + JSON.stringify(foundPartials["$" + name]) + ")";
+        return "require(" + loaderUtils.stringifyRequest(loaderApi, foundPartials["$" + name]) + ")";
       }
       foundPartials["$" + name] = null;
       return JavaScriptCompiler.prototype.nameLookup.apply(this, arguments);
     }
     else if (type === "helper") {
       if (foundHelpers["$" + name]) {
-        return "__default(require(" + JSON.stringify(foundHelpers["$" + name]) + "))";
+        return "__default(require(" + loaderUtils.stringifyRequest(loaderApi, foundHelpers["$" + name]) + "))";
       }
       foundHelpers["$" + name] = null;
       return JavaScriptCompiler.prototype.nameLookup.apply(this, arguments);
@@ -117,7 +117,7 @@ module.exports = function(source) {
   if (inlineRequires) {
     MyJavaScriptCompiler.prototype.pushString = function(value) {
       if (inlineRequires.test(value)) {
-        this.pushLiteral("require(" + JSON.stringify(value) + ")");
+        this.pushLiteral("require(" + loaderUtils.stringifyRequest(loaderApi, value) + ")");
       } else {
         JavaScriptCompiler.prototype.pushString.call(this, value);
       }
@@ -127,7 +127,7 @@ module.exports = function(source) {
       if (str.indexOf && str.indexOf('"') === 0) {
         var replacements = findNestedRequires(str, inlineRequires);
         str = fastreplace(str, replacements, function (match) {
-          return "\" + require(" + JSON.stringify(match) + ") + \"";
+          return "\" + require(" + loaderUtils.stringifyRequest(loaderApi, match) + ") + \"";
         });
       }
       return JavaScriptCompiler.prototype.appendToBuffer.apply(this, arguments);
@@ -374,7 +374,7 @@ module.exports = function(source) {
 
       // export as module if template is not blank
       var slug = template ?
-        'var Handlebars = require(' + JSON.stringify(runtimePath) + ');\n'
+        'var Handlebars = require(' + loaderUtils.stringifyRequest(loaderApi, runtimePath) + ');\n'
         + 'function __default(obj) { return obj && (obj.__esModule ? obj["default"] : obj); }\n'
         + 'module.exports = (Handlebars["default"] || Handlebars).template(' + template + ');' :
         'module.exports = function(){return "";};';


### PR DESCRIPTION
[Per Webpack's documentation on building loaders,](https://webpack.js.org/contribute/writing-a-loader/#absolute-paths) the [loader-utils package's `stringifyRequest` method](https://github.com/webpack/loader-utils#stringifyrequest) should be used by loaders to avoid hash-breaking absolute paths. [(See this article for more details on the broken hash problem.)](https://medium.com/@the_teacher/webpack-different-assets-hashes-on-different-machines-the-problem-the-solution-ec6383983b99)

This PR applies Webpack's recommendation to handlebars-loader.

All tests pass. Since the stringifyRequest method is a part of the Webpack loader-utils package and acts as a drop-in replacement for JSON.stringify I didn't think additional tests seemed necessary, but please let me know if you'd like to see something added.