### PR TITLE
Support of srcset with inlineRequires

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ example/dist/
 obj/
 .ntvs_analysis.dat.tmp
 coverage
+/.idea

--- a/index.js
+++ b/index.js
@@ -155,7 +155,7 @@ module.exports = function (source) {
               var srcsetProperty = srcsetMatch.replace(',', '').trim();
               requireList.push('" + require(' +
                   loaderUtils.stringifyRequest(loaderApi, srcsetPath) +
-                  ') + "' + srcsetProperty);
+                  ') + " ' + srcsetProperty);
               startIndex = item.index + srcsetMatch.length;
             });
 

--- a/lib/srcset.js
+++ b/lib/srcset.js
@@ -1,0 +1,10 @@
+var srcsetRegex = /(\s+\d+w($|\s*,)|\s+\d+x($|\s*,))/;
+
+function hasSrcsetProperties(match) {
+    return new RegExp(srcsetRegex).test(match);
+}
+
+module.exports = {
+    srcsetRegex: srcsetRegex,
+    hasSrcsetProperties: hasSrcsetProperties,
+};

--- a/test/with-inline-requires.handlebars
+++ b/test/with-inline-requires.handlebars
@@ -1,1 +1,6 @@
 {{image "images/path/to/image"}}
+
+<img src="images/path/to/image" srcset="images/path/to/200/image 200w" />
+
+<img src="images/path/to/image" srcset="images/path/to/200/image 200w, images/path/to/400/image 400w, images/path/to/2x/image 2x" />
+


### PR DESCRIPTION
This is a follow up to [mmousawy](https://github.com/mmousawy)'s PR, applied to the latest code. Fixes #148 and adds  `srcset` support when `inlineRequires` is matched.